### PR TITLE
Remove generation and observation queues

### DIFF
--- a/aiomessaging/consumers/manager.py
+++ b/aiomessaging/consumers/manager.py
@@ -10,7 +10,6 @@ from ..queues import QueueBackend
 from ..config import Config
 from ..router import Router
 from ..cluster import Cluster
-from ..utils import class_from_string
 
 from .event import EventConsumer
 from .message import MessageConsumer
@@ -83,16 +82,12 @@ class ConsumersManager:
             loop=self.loop
         )
         self.cluster.on_start_consume(self.consume_generation_queue)
-        self.cluster.on_output_observed(self.cluster_on_output_observed)
+        self.cluster.on_output_observed(self.on_cluster_output_observed)
         await self.cluster.start()
 
-    async def cluster_on_output_observed(self, event_type, output):
+    async def on_cluster_output_observed(self, event_type, output):
         """Handle output observation from cluster.
         """
-        # TODO: need to find better approach?
-        cls_path, args, kwargs = output
-        OutputCls = class_from_string(cls_path)
-        output = OutputCls.load(args, kwargs)
         await self.start_output_consumer(event_type, output.name)
 
     async def consume_generation_queue(self, queue_name):

--- a/aiomessaging/consumers/manager.py
+++ b/aiomessaging/consumers/manager.py
@@ -10,6 +10,7 @@ from ..queues import QueueBackend
 from ..config import Config
 from ..router import Router
 from ..cluster import Cluster
+from ..utils import class_from_string
 
 from .event import EventConsumer
 from .message import MessageConsumer
@@ -17,6 +18,7 @@ from .output import OutputConsumer
 from .generation import GenerationConsumer
 
 
+# pylint: disable=too-many-instance-attributes
 class ConsumersManager:
 
     """Consumers manager.
@@ -85,8 +87,10 @@ class ConsumersManager:
         await self.cluster.start()
 
     async def cluster_on_output_observed(self, event_type, output):
+        """Handle output observation from cluster.
+        """
+        # TODO: need to find better approach?
         cls_path, args, kwargs = output
-        from ..utils import class_from_string
         OutputCls = class_from_string(cls_path)
         output = OutputCls.load(args, kwargs)
         await self.start_output_consumer(event_type, output.name)

--- a/aiomessaging/consumers/manager.py
+++ b/aiomessaging/consumers/manager.py
@@ -54,7 +54,7 @@ class ConsumersManager:
         if loop:
             self.loop = loop
 
-        await self.listen_generation()
+        await self.start_generation_consumer()
         await self.create_cluster()
         await self.create_event_consumers()
         await self.create_message_consumers()
@@ -65,7 +65,7 @@ class ConsumersManager:
         """
         await self.cluster.stop()
 
-        await self.stop_listen_generation()
+        await self.stop_generation_consumer()
 
         await stop_all(self.event_consumers)
         await stop_all(self.message_consumers)
@@ -173,10 +173,8 @@ class ConsumersManager:
         )
         await self.output_consumers[output][event_type].start()
 
-    async def listen_generation(self):
+    async def start_generation_consumer(self):
         """Listen generation queue of cluster for queue names to consume.
-
-        TODO: rename
 
         Creates consumer for generated messages when cluster event received.
         """
@@ -188,7 +186,7 @@ class ConsumersManager:
         )
         await self.generation_consumer.start()
 
-    async def stop_listen_generation(self):
+    async def stop_generation_consumer(self):
         """Stop listen for generation queues.
         """
         await self.generation_consumer.stop()

--- a/aiomessaging/consumers/message.py
+++ b/aiomessaging/consumers/message.py
@@ -2,6 +2,8 @@
 """
 import asyncio
 
+from typing import Callable
+
 from ..message import Message
 from ..router import Router
 from ..queues import AbstractQueue
@@ -33,15 +35,19 @@ class MessageConsumer(BaseMessageConsumer):
     event_type: str
     router: Router
     output_queue: AbstractQueue
-    output_observation_queue: asyncio.Queue
+    output_observed_handler: Callable
 
     def __init__(self, event_type, router: Router, output_queue,
-                 output_observation_queue, **kwargs) -> None:
+                 **kwargs) -> None:
         super().__init__(**kwargs)
         self.event_type = event_type
         self.router = router
         self.output_queue = output_queue
-        self.output_observation_queue = output_observation_queue
+
+    def on_output_observed(self, handler):
+        """Set output observed handler.
+        """
+        self.output_observed_handler = handler
 
     async def handle_message(self, message: Message):
         """Message handler.
@@ -59,9 +65,8 @@ class MessageConsumer(BaseMessageConsumer):
                     output = action.get_output()
 
                     # manager will create output consumer for us if possible
-                    await self.output_observation_queue.put(
-                        [self.event_type, output]
-                    )
+                    if hasattr(self, 'output_observed_handler'):
+                        await self.output_observed_handler(self.event_type, output)
 
                     await self.output_queue.publish(
                         message.to_dict(), routing_key=output.name

--- a/aiomessaging/consumers/message.py
+++ b/aiomessaging/consumers/message.py
@@ -1,7 +1,5 @@
 """Message consumer.
 """
-import asyncio
-
 from typing import Callable
 
 from ..message import Message

--- a/aiomessaging/queues/backend.py
+++ b/aiomessaging/queues/backend.py
@@ -239,7 +239,7 @@ class QueueBackend:
             routing_key=''
         )
 
-    async def output_queue(self, event_type, output_name=None) -> Queue:
+    async def output_queue(self, event_type: str, output_name=None) -> Queue:
         """Get output queue.
         """
         name = f"output.{event_type}"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,8 @@ tests helpers
 import logging
 import asyncio
 
+from unittest.mock import Mock
+
 from aiomessaging.queues import QueueBackend
 from aiomessaging.consumers import OutputConsumer, MessageConsumer
 from aiomessaging.router import Router
@@ -63,7 +65,6 @@ class MessageConsumerContext:
             router=router,
             output_queue=output_queue,
             queue=queue,
-            output_observation_queue=asyncio.Queue(),
         )
         await self.message_consumer.start()
         return self.message_consumer
@@ -116,3 +117,11 @@ async def wait_messages(consumer, count=1):
     """
     for _ in range(count):
         await consumer.last_messages.get()
+
+
+def mock_coro(return_value=None):
+    @asyncio.coroutine
+    def mock_coro(*args, **kwargs):
+        return return_value
+
+    return Mock(wraps=mock_coro)

--- a/tests/test_event_consumer.py
+++ b/tests/test_event_consumer.py
@@ -21,7 +21,7 @@ async def test_start(event_loop: asyncio.AbstractEventLoop, caplog):
     await backend.connect()
 
     queue = await backend.cluster_queue()
-    cluster = Cluster(queue=queue, generation_queue=asyncio.Queue(), loop=event_loop)
+    cluster = Cluster(queue=queue, loop=event_loop)
     await cluster.start()
 
     def test_callable(event):
@@ -37,7 +37,6 @@ async def test_start(event_loop: asyncio.AbstractEventLoop, caplog):
         loop=event_loop,
         event_pipeline=pipeline,
         generators=generators,
-        generation_queue=asyncio.Queue(),
         queue_service=backend,
         queue=queue
     )
@@ -61,7 +60,7 @@ async def test_error_handler(event_loop: asyncio.AbstractEventLoop, caplog):
     await backend.connect()
 
     queue = await backend.cluster_queue()
-    cluster = Cluster(queue=queue, generation_queue=asyncio.Queue(), loop=event_loop)
+    cluster = Cluster(queue=queue, loop=event_loop)
     await cluster.start()
 
     pipeline = EventPipeline([])
@@ -74,7 +73,6 @@ async def test_error_handler(event_loop: asyncio.AbstractEventLoop, caplog):
         loop=event_loop,
         event_pipeline=pipeline,
         generators=generators,
-        generation_queue=asyncio.Queue(),
         queue_service=backend,
         queue=queue
     )

--- a/tests/test_message_consumer.py
+++ b/tests/test_message_consumer.py
@@ -31,7 +31,6 @@ async def test_simple(event_loop, caplog):
         router=router,
         output_queue=output_queue,
         queue=queue,
-        output_observation_queue=asyncio.Queue(),
         loop=event_loop
     )
 
@@ -60,7 +59,6 @@ async def test_any_output_available(event_loop, caplog):
         router=router,
         output_queue=output_queue,
         queue=queue,
-        output_observation_queue=asyncio.Queue(),
         loop=event_loop
     )
 


### PR DESCRIPTION
There is no need in generation_queue and output_observation_queue to communicate consumers. Just use simlified pub/sub (add callback from outside and invoke it from inside of consumer when event occurred).